### PR TITLE
Don't tag during `npm version`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         scope: '@determinate-systems'
         node-version: '22'
-    - run: npm version "$TAG"
+    # We're getting tags from GitHub, so this is irrelevant
+    - run: npm version --no-git-tag-version "$TAG"
       env:
         TAG: ${{ github.ref_name }}
     - run: npm publish --provenance


### PR DESCRIPTION
By default, the `npm version` command wants to create a new Git tag since it detects a checkout. We don't want that since we'll be tagging from the GitHub UI.