### PR TITLE
Run `npm ci` before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     - run: npm version --no-git-tag-version "$TAG"
       env:
         TAG: ${{ github.ref_name }}
+    - run: npm ci
     - run: npm publish --provenance
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Might be useful if we had our build tools when we did a build...