### PR TITLE
Fix Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "npm ci && npm run build-storybook"
+command = "npm ci && npm run build && npm run build-storybook"
 publish = "storybook-static"
 
 [build.environment]


### PR DESCRIPTION
Apparently the Rollup build needs to populate `lib` before we can build the Storybook site.
