### PR TITLE
Add HTML preview

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,7 +13,8 @@ const config: StorybookConfig = {
       }
     },
     "@storybook/addon-onboarding",
-    "@storybook/addon-interactions"
+    "@storybook/addon-interactions",
+    "@whitespace/storybook-addon-html",
   ],
   "framework": {
     "name": "@storybook/react-vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@determinate-systems/ui",
       "version": "0.0.1",
+      "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
@@ -19,6 +20,7 @@
         "@storybook/react-vite": "^8.6.14",
         "@storybook/test": "^8.6.14",
         "@types/react": "^19.1.4",
+        "@whitespace/storybook-addon-html": "^7.0.0",
         "esbuild": "^0.25.4",
         "rollup": "^4.41.0",
         "rollup-plugin-sass": "^1.15.2",
@@ -2412,6 +2414,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@whitespace/storybook-addon-html": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-7.0.0.tgz",
+      "integrity": "sha512-GCpy1Xch7v3UZ/TmKUFnF0lFEt6qct/zqO/64LfoEOwr3zV5YDdidHBURSNp5qK8Q68wPLs/nVhbAzAEvudR8w==",
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "peerDependencies": {
+        "storybook": "^8.2.0"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@storybook/react-vite": "^8.6.14",
     "@storybook/test": "^8.6.14",
     "@types/react": "^19.1.4",
+    "@whitespace/storybook-addon-html": "^7.0.0",
     "esbuild": "^0.25.4",
     "rollup": "^4.41.0",
     "rollup-plugin-sass": "^1.15.2",


### PR DESCRIPTION
This adds an HTML preview to the Storybook setup:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/718de549-98ba-4309-86d4-013421aa2c4f" />

Seems reasonable to provide given that we're likely to have UI consumers that use plain old HTML.