### PR TITLE
Fix font specification

### DIFF
--- a/src/CodeFile/index.scss
+++ b/src/CodeFile/index.scss
@@ -1,0 +1,7 @@
+@use "sass:map";
+
+@use "../sass/tokens";
+
+.code-file__heading code {
+  font-family: map.get(tokens.$fonts, mono);
+}

--- a/src/CodeFile/index.tsx
+++ b/src/CodeFile/index.tsx
@@ -5,6 +5,8 @@ import CopyButton from "../CopyButton";
 import DownloadButton from "../DownloadButton";
 import Highlight from "../Highlight";
 
+import "./index.scss";
+
 export interface CodeFileProps {
   language: HighlightLanguage;
   code: string;

--- a/src/Highlight/index.scss
+++ b/src/Highlight/index.scss
@@ -21,6 +21,8 @@ $shiki-light-bg: #fff;
   span {
     color: var(--shiki-dark);
 
+    font-family: map.get(tokens.$fonts, mono);
+
     @include mixins.light-mode {
       color: var(--shiki-light);
     }

--- a/src/MacInstaller/index.scss
+++ b/src/MacInstaller/index.scss
@@ -15,6 +15,8 @@
   color: map.get(tokens.$brand, white);
   text-decoration: none;
 
+  font-family: map.get(tokens.$fonts, sans);
+
   padding: 1rem;
   border-radius: 0.5rem;
 

--- a/src/sass/_tokens.scss
+++ b/src/sass/_tokens.scss
@@ -19,9 +19,20 @@ $code: (
 );
 
 $fonts: (
-  sans: '"Work Sans", sans-serif',
-  mono:
-    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  sans: (
+    "Work Sans",
+    sans-serif,
+  ),
+  mono: (
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace,
+  ),
 );
 
 $duration: (


### PR DESCRIPTION
Apparently there's a nice way to do this in Sass rather than passing a gnarly string.

Note the sans font not being applied here: https://determinate-ui.netlify.app/?path=/docs/molecules-codeblock--docs
