### PR TITLE
Bump patch version to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@determinate-systems/ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@determinate-systems/ui",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@determinate-systems/ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
The generated CSS from `main` is now substantial-ish enough that I can start playing with it in other contexts. This patch bump is pretty much just for publishing recent components to unpkg.
