### PR TITLE
Tweak publishing config and add verbosity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,6 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: npm publish --verbose --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "files": [
     "lib/"
   ],
-  "repository": "github:DeterminateSystems/ui",
-  "publishConfig": {
-    "provenance": true
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DeterminateSystems/ui.git"
   },
   "scripts": {
     "build": "rollup -c rollup.config.mjs",


### PR DESCRIPTION
At this point, the v0.0.3 tag should've appeared in the registry but didn't. This PR makes some tweaks to appease npm:

1. We only use command-line flags to avoid `publishConfig` taking precedence.
2. The `repository` field is set to a structured object as requested by `npm`.
3. I've added `--verbose` to the publish process so that we can get more info.