### PR TITLE
Handle color schemes with context

### DIFF
--- a/src/ColorContext/index.tsx
+++ b/src/ColorContext/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export type ColorScheme = 'light' | 'dark';
+
+export interface ColorContextValue {
+  readonly scheme: ColorScheme;
+  readonly setScheme: (scheme: ColorScheme) => void;
+}
+
+const ColorContext = React.createContext<ColorContextValue>(null!);
+
+export default ColorContext;

--- a/src/ColorContext/index.tsx
+++ b/src/ColorContext/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-export type ColorScheme = 'light' | 'dark';
+export type ColorScheme = "light" | "dark";
 
 export interface ColorContextValue {
   readonly scheme: ColorScheme;

--- a/src/ColorProvider/index.tsx
+++ b/src/ColorProvider/index.tsx
@@ -1,0 +1,70 @@
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+import ColorContext, {
+  type ColorContextValue,
+  type ColorScheme,
+} from "../ColorContext";
+
+export interface ColorProviderProps {
+  /** Root element for this color context. Defaults to the HTML `<body>` element, but can be scoped more narrowly for testing. */
+  root?: Element;
+
+  /** Which color scheme to use by default. If omitted, queries the CSS engine. */
+  initialColorScheme?: ColorScheme;
+}
+
+function computeInitialColorScheme(initial?: ColorScheme): ColorScheme {
+  if (typeof initial !== "undefined") {
+    return initial;
+  }
+
+  // In case we're doing server-side rendering, just render `light` and be done with it.
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  // TODO: read from local storage
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+// Helper component for
+const ColorProvider: React.FC<PropsWithChildren<ColorProviderProps>> = ({
+  initialColorScheme,
+  root = document.body,
+  children,
+}) => {
+  const [scheme, setScheme] = useState(() =>
+    computeInitialColorScheme(initialColorScheme),
+  );
+
+  // Since we're pretty high up in the component tree, we want to be extremely
+  // careful about re-rendering. Memoization ensures that the object only
+  // changes when the scheme does.
+  const value = useMemo<ColorContextValue>(
+    () => ({ scheme, setScheme }),
+    [scheme],
+  );
+
+  // Switch body classes depending on the chosen scheme
+  useEffect(() => {
+    const classes = root.classList;
+    const [next, previous] =
+      scheme === "light" ? ["light", "dark"] : ["dark", "light"];
+
+    classes.add(`color-scheme--${next}`);
+    classes.remove(`color-scheme--${previous}`);
+  }, [scheme]);
+
+  return (
+    <ColorContext.Provider value={value}>{children}</ColorContext.Provider>
+  );
+};
+
+export default ColorProvider;

--- a/src/ColorProvider/index.tsx
+++ b/src/ColorProvider/index.tsx
@@ -23,9 +23,9 @@ function computeInitialColorScheme(initial?: ColorScheme): ColorScheme {
     return initial;
   }
 
-  // In case we're doing server-side rendering, just render `light` and be done with it.
+  // In case we're doing server-side rendering, just render `dark` be done with it.
   if (typeof window === "undefined") {
-    return "light";
+    return "dark";
   }
 
   // TODO: read from local storage

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,15 @@ export { default as useObjectURL } from "./hooks/useObjectURL";
 export { type ButtonProps, default as Button } from "./Button";
 export { type CodeBlockProps, default as CodeBlock } from "./CodeBlock";
 export { type CodeFileProps, default as CodeFile } from "./CodeFile";
+export {
+  type ColorContextValue,
+  type ColorScheme,
+  default as ColorContext,
+} from "./ColorContext";
+export {
+  type ColorProviderProps,
+  default as ColorProvider,
+} from "./ColorProvider";
 export { type CopyButtonProps, default as CopyButton } from "./CopyButton";
 export {
   type DownloadButtonProps,


### PR DESCRIPTION
By using this approach, CSS can query the `.color-scheme--${scheme}` class on a parent element, and React components can query the `ColorContext`.