### PR TITLE
Let chromatic exit before the remote finished

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,3 +20,4 @@ jobs:
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitOnceUploaded: true


### PR DESCRIPTION
This is fine since we use their status reports as blocking.