### PR TITLE
Use OIDC for publishing

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-          scope: "@determinate-systems"
-          node-version: "22"
+      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
       # We're getting tags from GitHub, so this is irrelevant
-      - run: npm version --no-git-tag-version "$TAG"
+      - run: nix develop .#deploy -c npm version --no-git-tag-version "$TAG"
         env:
           TAG: ${{ github.ref_name }}
-      - run: npm ci
-      - run: npm publish --verbose --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: nix develop .#deploy -c npm ci
+      - run: nix develop .#deploy -c npm publish --verbose --access public

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747533086,
-        "narHash": "sha256-+8goyptSXa7qV0k5uPKyky58jpBjI/qkzsbwCZFvhRY=",
-        "rev": "8406224e30c258025cb8b31704bdb977a8f1f009",
-        "revCount": 802343,
+        "lastModified": 1756696532,
+        "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
+        "rev": "58dcbf1ec551914c3756c267b8b9c8c86baa1b2f",
+        "revCount": 854745,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.802343%2Brev-8406224e30c258025cb8b31704bdb977a8f1f009/0196ec33-1ffa-76fa-ad14-ac737caf6446/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nixpkgs-weekly/0.1.854745%2Brev-58dcbf1ec551914c3756c267b8b9c8c86baa1b2f/019908ed-e731-796e-b7c5-ea173f5d3b8d/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
 
           buildInputs = [
             pkgs.codespell
-            pkgs.nodejs
+            pkgs.nodejs_latest
           ];
         };
 
@@ -37,7 +37,7 @@
           name = "publish";
 
           buildInputs = [
-            pkgs.nodejs
+            pkgs.nodejs_latest
           ];
         };
       });


### PR DESCRIPTION
This PR changes the publishing workflow to use npm's new [trusted publishers](https://docs.npmjs.com/trusted-publishers#for-github-actions) configuration, where OIDC is used to authenticate instead of a granular access token. This required a bump of nixpkgs so that `pkgs.nodejs_latest` gives us the npm CLI at version 11.5.1.

Additionally, as a matter of housekeeping, `actions/checkout` is bumped to v5.