### PR TITLE
Bring the base font-size to 1rem

### DIFF
--- a/src/sass/_tokens.scss
+++ b/src/sass/_tokens.scss
@@ -72,9 +72,9 @@ $padding: (
 );
 
 $font-size: (
-  sm: 1rem,
-  base: 1.25rem,
-  lg: 1.5rem,
+  sm: 0.75rem,
+  base: 1rem,
+  lg: 1.25rem,
 );
 
 $duration: (


### PR DESCRIPTION
A base of 1.25 means pushing a lot of sort of base-ish sized text needing to select "sm" which is awkward, since it really isn't small.

Now "sm" is 0.75 and "base" is 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global font-size scale:
    * sm: 1rem → 0.75rem
    * base: 1.25rem → 1rem
    * lg: 1.5rem → 1.25rem
  * Impact: Text across the app will render slightly smaller, affecting body copy, headings, and small text for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->